### PR TITLE
fix: correct sample links in example admin application

### DIFF
--- a/examples/Kentico.Xperience.UMT.Example.AdminApp/Client/src/custom-layout/CustomLayoutTemplate.tsx
+++ b/examples/Kentico.Xperience.UMT.Example.AdminApp/Client/src/custom-layout/CustomLayoutTemplate.tsx
@@ -79,7 +79,7 @@ export const CustomLayoutTemplate = ({ label }: CustomLayoutProps) => {
                             headline="Basic usage"
                             subheadline="Info"
                         >
-                            Component <a target="_blank" href="https://github.com/Kentico/xperience-by-kentico-universal-migration-toolkit/blob/main/Docs/README.md">documentation</a> and <a target="_blank" href="https://github.com/Kentico/xperience-by-kentico-universal-migration-toolkit/tree/main/Docs/Samples">samples</a>
+                            Component <a target="_blank" href="https://github.com/Kentico/xperience-by-kentico-universal-migration-toolkit/blob/main/docs/README.md">documentation</a> and <a target="_blank" href="https://github.com/Kentico/xperience-by-kentico-universal-migration-toolkit/tree/main/docs/Samples">samples</a>
                         </Callout>
 
                         <div className={transitionClass(backgroundTransition)}>


### PR DESCRIPTION
# Motivation

The current links configured for the sample interface within the admin application are incorrect and go to a 404. This PR corrects the casing in the URL for the `docs` folder.

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
